### PR TITLE
Update 02_diffusion_as_memory.ipynb

### DIFF
--- a/tutorial_ipynbs/02_diffusion_as_memory.ipynb
+++ b/tutorial_ipynbs/02_diffusion_as_memory.ipynb
@@ -380,7 +380,7 @@
     "$$\n",
     "\\nabla_{\\tilde{\\mathbf{x}}} \\log p(\\tilde{\\mathbf{x}} | \\mathbf{x}) = \\nabla_\\tilde{\\mathbf{x}} \\bigg ( -\\frac{1}{2\\sigma^2} (\\tilde{\\mathbf{x}} - \\mathbf{x})^2 \\bigg ) = -\\frac{\\tilde{\\mathbf{x}} - \\mathbf{x}}{\\sigma^2} = -\\frac{\\mathbf{z}}{\\sigma}\n",
     "$$\n",
-    "as the score function, which we have to learn for a single timestep of denoising. $\\mathbf{z} \\sim \\mathcal{N}(0, \\mathbf{I})$."
+    "as the score function, which we have to learn for a single timestep of denoising."
    ]
   },
   {


### PR DESCRIPTION
Got rid of \mathbf{z} \sim \mathcal{N}(0, \mathbf{I}).